### PR TITLE
Add node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-core": "^6.1.21",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
-    "babelify": "^7.2.0"
+    "babelify": "^7.2.0",
+    "node-sass": "^3.4.2"
   }
 }


### PR DESCRIPTION
`npm run build` was failing without `node-sass` dev dependency.
